### PR TITLE
fix: support small floats in UI inputs

### DIFF
--- a/tesseract_streamlit/templates/template.j2
+++ b/tesseract_streamlit/templates/template.j2
@@ -90,6 +90,7 @@ st.markdown({% if not udf.docs %}""{% else %}
 {{ field.uid }} = {{ field.container }}.number_input(
     "{{ field.get('title', field.uid) }}",
     key="number.{{ field.key }}",
+    format="%f",
     value={{ field.get("default", None) }},
 )
 {% elif field.type == 'boolean' %}


### PR DESCRIPTION
#### Relevant issue or PR
<!-- If the changes resolve an issue or follow some other PR, link to them here. GitHub references are strongly preferred, but links to other resources, such as Jira or Confluence, can also be used. Only link something if it is directly relevant. -->
Replaces #16.

#### Description of changes
<!-- Add a high-level description of changes, focusing on the *what* and *why*. -->
Add UI formatting for numbers with small magnitudes, _ie._ `1.45e-9`.

#### Testing done
<!-- Describe how the changes were tested; e.g., "CI passes", "Tested manually in stagingrepo#123", screenshots of a terminal session that verify the changes, or any other evidence of testing the changes. -->
Manual testing in web UI.