### PR TITLE
feat: handle bad url with friendly error message

### DIFF
--- a/tesseract_streamlit/cli.py
+++ b/tesseract_streamlit/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import typer
 from jinja2 import Environment, FileSystemLoader
+from requests.exceptions import ConnectionError
 from rich.console import Console
 
 from tesseract_streamlit.config import _copy_favicon
@@ -66,7 +67,18 @@ def main(
         lstrip_blocks=True,
     )
     template = env.get_template("templates/template.j2")
-    render_kwargs = extract_template_data(url, user_code)
+    try:
+        render_kwargs = extract_template_data(url, user_code)
+    except ConnectionError as e:
+        err_console.print(
+            "[bold red]Error: [/bold red]"
+            f"Can't seem to find the Tesseract at {url}. "
+            "Are you sure it's being served?\n\n"
+            "[bold green]Hint: [/bold green]"
+            "You can double check using `tesseract ps`. If it's being served, "
+            "you can find the correct URL in the 'Host Address' column."
+        )
+        raise typer.Exit(code=3) from e
     rendered_code = template.render(
         **render_kwargs,
         test=test,


### PR DESCRIPTION
#### Description of changes
<!-- Add a high-level description of changes, focusing on the *what* and *why*. -->

Catch ConnectionError exceptions when thrown due to URLs not pointing to served Tesseracts.
The error is then replaced with a friendly message, and suggestion to look under tesseract ps to see if the Tesseract is running. Typer then exits, with an exit code of 3.

#### Testing done

Manually tested.

<img width="1920" height="372" alt="image" src="https://github.com/user-attachments/assets/035742ea-664f-4696-b7e9-d4743fd2d75b" />
