### PR TITLE
fix: add support for multiline descriptions

### DIFF
--- a/tesseract_streamlit/templates/template.j2
+++ b/tesseract_streamlit/templates/template.j2
@@ -72,7 +72,9 @@ st.markdown({% if not udf.docs %}""{% else %}
 {# next, add subheading and descriptive text #}
 {{ field.container }}.subheader("{{ field.title }}")
 {% if field.description %}
-{{ field.container }}.caption("{{ field.description }}")
+{{ field.container }}.caption(
+    {{- multiline(field.description) | indent(4) }}
+)
 {% endif %}
 {# identify which type of Streamlit element to render based on field type #}
 {% if field.type == 'string' %}

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,3 +1,4 @@
+import ast
 import random
 import typing
 from pathlib import Path
@@ -5,8 +6,11 @@ from pathlib import Path
 import orjson
 import pytest
 import pyvista as pv
+from jinja2 import Environment, FileSystemLoader
 
 from tesseract_streamlit import parse
+
+PACKAGE_DIR = Path(__file__).parent.parent / "tesseract_streamlit"
 
 PARENT_DIR = Path(__file__).parent
 
@@ -129,6 +133,41 @@ def test_metadata_extract(mock_schema: bytes) -> None:
     for key, val in reference_vals.items():
         message = f"Tesseract {key} incorrectly extracted."
         assert val == metadata[key], message
+
+
+def test_newline_in_field_description() -> None:
+    """Descriptions with newlines must not produce invalid Python (GH-87)."""
+    env = Environment(
+        loader=FileSystemLoader(str(PACKAGE_DIR)),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    template = env.get_template("templates/template.j2")
+    schema = [
+        parse.JinjaField(
+            container="container_foo",
+            parent_container="st",
+            uid="foo",
+            stem="foo",
+            key="foo",
+            type="array",
+            title="Foo",
+            description="first line\nsecond line",
+            number_constraints={},
+        ),
+    ]
+    rendered = template.render(
+        schema=schema,
+        metadata={"title": "T", "version": "0", "description": "d"},
+        url="http://localhost:0",
+        needs_pyvista=False,
+        udfs=None,
+        udf_defs=None,
+        test=True,
+        favicon_path="icon.png",
+    )
+    # The rendered code must be valid Python — this was the bug in GH-87
+    ast.parse(rendered)
 
 
 def test_description_from_oas(


### PR DESCRIPTION
#### Relevant issue or PR

Fixes #87 

#### Description of changes

Having `\n` in Tesseract descriptions no longer raises an exception. It is now replaced with a space character.

#### Testing done

CI
